### PR TITLE
Add 'metrics' flag to specify available metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Store data in InfluxDB from sitespeed.io. This plugin was included in sitespeed.io before sitespeed.io 37 was released. After that version you need to install it yourself.
  
 ## Install the plugin
-If you use NodeJs the simplest way is to install the plugin globally: `npm install @sitespeed.io/plugin-influxdb -g`
+If you use Node.js the simplest way is to install the plugin globally: `npm install @sitespeed.io/plugin-influxdb -g`
 
 
 ## Run the plugin
-And then run sitespeed.io adding the pluging using the package name: `sitespeed.io --plugins.add @sitespeed.io/plugin-influxdb --influxdb.host YOUR_HOST https://www.sitespeed.io`
+And then run sitespeed.io adding the plugin using the package name: `sitespeed.io --plugins.add @sitespeed.io/plugin-influxdb --influxdb.host YOUR_HOST https://www.sitespeed.io`
 
 ## CLI help
 To see the command line options using help:

--- a/lib/data-generator.js
+++ b/lib/data-generator.js
@@ -154,7 +154,7 @@ function getAdditionalTags(key, type) {
   return tags;
 }
 
-function getFieldAndSeriesName(key) {
+function getFieldAndSeriesName(key, options) {
   const functions = [
     'min',
     'p10',
@@ -168,9 +168,14 @@ function getFieldAndSeriesName(key) {
     'stddev',
     'rsd'
   ];
+
+  const availableMetrics = options.influxdb.metrics
+    ? options.influxdb.metrics.split(',')
+    : functions;
+
   const keyArray = key.split('.');
   const end = keyArray.pop();
-  if (functions.includes(end)) {
+  if (availableMetrics.includes(end)) {
     return { field: end, seriesName: keyArray.pop() };
   }
   return { field: 'value', seriesName: end };
@@ -237,7 +242,7 @@ export class InfluxDBDataGenerator {
     }
     return Object.entries(flattenMessageData(message)).reduce(
       (entries, [key, value]) => {
-        const fieldAndSeriesName = getFieldAndSeriesName(key);
+        const fieldAndSeriesName = getFieldAndSeriesName(key, this.options);
         let tags = getTagsFromMessage(
           message,
           this.includeQueryParams,


### PR DESCRIPTION
New flag to control list of available metrics due to reduce metric data size
```
--influxdb.metrics='mean,max'
```